### PR TITLE
Header component and cleanup

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -12,10 +12,6 @@
 
   <body>
     <div class='container'>
-      <div class='jumbotron' style='text-align:center;'>
-        <h1>DnD</h1>
-        <p>Enjoy learning about DnD!</p>
-      </div>
       <div id="content"></div>
     </div>
   </body>

--- a/public/scripts/character.jsx
+++ b/public/scripts/character.jsx
@@ -2,7 +2,7 @@
 
 const React: any = require('react');
 
-import CharacterEquipment from './character_equipment.jsx';
+import CharacterEquipment from './character_equipment';
 import {
   fetchDataFromUri,
 } from './network_request_helpers.jsx';

--- a/public/scripts/character_equipment.jsx
+++ b/public/scripts/character_equipment.jsx
@@ -2,7 +2,7 @@ const React: any = require('react');
 
 import {
   renderDictionary,
-} from './render_helpers.jsx'
+} from './render_helpers'
 
 export default function CharacterEquipment(props: {equipment: Object}) {
   return (

--- a/public/scripts/dnd_container.jsx
+++ b/public/scripts/dnd_container.jsx
@@ -3,11 +3,11 @@
 const React: any = require('react');
 const Modal = require('react-modal');
 
-import Character from './character.jsx';
-import Grid from './grid.jsx';
-import Header from './header.jsx';
-import List from './list.jsx';
-import Spell from './spell.jsx';
+import Character from './character';
+import Grid from './grid';
+import Header from './header';
+import List from './list';
+import Spell from './spell';
 
 type DNDContainerProps = {};
 

--- a/public/scripts/dnd_container.jsx
+++ b/public/scripts/dnd_container.jsx
@@ -5,6 +5,7 @@ const Modal = require('react-modal');
 
 import Character from './character.jsx';
 import Grid from './grid.jsx';
+import Header from './header.jsx';
 import List from './list.jsx';
 import Spell from './spell.jsx';
 
@@ -17,7 +18,7 @@ export default class DNDContainer extends React.Component {
     isModalOpen: boolean,
     selectedCharacterName: ?string,
     selectedSpell: ?Object,
-  }
+  };
 
   constructor(props: DNDContainerProps): void {
     super(props);
@@ -156,6 +157,7 @@ export default class DNDContainer extends React.Component {
 
     return (
       <div>
+        <Header />
         <List
           items={['Green Archer']}
           componentBlock={this.renderCharacterButtons.bind(this)}

--- a/public/scripts/header.jsx
+++ b/public/scripts/header.jsx
@@ -1,0 +1,15 @@
+const React: any = require('react');
+
+export default function Header() {
+
+  const style = {
+    textAlign: 'center'
+  };
+
+  return (
+    <div className='jumbotron' style={style}>
+      <h1>DnD</h1>
+      <p>Enjoy learning about DnD!</p>
+    </div>
+  );
+};

--- a/public/scripts/header.jsx
+++ b/public/scripts/header.jsx
@@ -1,7 +1,6 @@
 const React: any = require('react');
 
 export default function Header() {
-
   const style = {
     textAlign: 'center'
   };

--- a/public/scripts/list.jsx
+++ b/public/scripts/list.jsx
@@ -10,7 +10,7 @@ type ListProps = {
 export default class List extends React.Component {
   props: ListProps;
 
-  state: {}
+  state: {};
 
   constructor(props: ListProps): void {
     super(props);

--- a/public/scripts/main.jsx
+++ b/public/scripts/main.jsx
@@ -3,7 +3,7 @@
 const React: any = require('react');
 const ReactDOM = require('react-dom');
 
-import DNDContainer from './dnd_container.jsx';
+import DNDContainer from './dnd_container';
 
 ReactDOM.render(
   <DNDContainer />,


### PR DESCRIPTION
To keep the `index.html` clean I moved the header into its own stateless component. Also removed the extensions on your imports since they weren't necessary and you might not want to have to change a lot of imports if you end up modifying a file extension. The webpack config has a `resolve` section that lists the extensions it'll look for so you should be fine as is.